### PR TITLE
Changed sort sign from "-" to "+"

### DIFF
--- a/src/components/farm/FarmLastAttemptedProof.tsx
+++ b/src/components/farm/FarmLastAttemptedProof.tsx
@@ -39,7 +39,7 @@ export default function FarmLastAttemptedProof() {
   const lastAttemptedProof = useSelector(
     (state: RootState) => state.farming_state.farmer.last_farming_info ?? [],
   );
-  const reducedLastAttemptedProof = lastAttemptedProof.slice(0, 5).sort((a,b) => a.timestamp-b.timestamp);
+  const reducedLastAttemptedProof = lastAttemptedProof.slice(0, 5).sort((a,b) => a.timestamp+b.timestamp);
   const isEmpty = !reducedLastAttemptedProof.length;
 
   return (


### PR DESCRIPTION
The last attempted proof list is updating the rows from bottom. Should be the inverse order, like the others. Please double check the change if it works.

Thank you